### PR TITLE
Add script to update subtask manager assignments

### DIFF
--- a/examples/change-manager-in-subtasks.ts
+++ b/examples/change-manager-in-subtasks.ts
@@ -109,6 +109,7 @@ async function fetchTasks(): Promise<TaskResponse[]> {
   let offset = 0;
 
   while (true) {
+    console.log(`Fetching tasks offset ${offset}`);
     const requestFields = `id,name,${managerFieldId}`;
     const response = await taskApi.getTaskList({
       getTaskListRequest: {
@@ -122,9 +123,9 @@ async function fetchTasks(): Promise<TaskResponse[]> {
             value: opts.templateId,
           },
           {
-            type: ComplexTaskFilterTypeEnum.NUMBER_71,
+            type: ComplexTaskFilterTypeEnum.USER,
             operator: ComplexTaskFilterOperatorEnum.Equal,
-            value: opts.userId,
+            value: `user:${opts.userId}`,
           },
         ],
       },

--- a/examples/change-manager-in-subtasks.ts
+++ b/examples/change-manager-in-subtasks.ts
@@ -1,0 +1,251 @@
+import {
+  ObjectApi,
+  TaskApi,
+  ComplexTaskFilterOperatorEnum,
+  ComplexTaskFilterTypeEnum,
+  TaskResponse,
+} from '../src/generated';
+import { loadConfig } from '../src/config';
+import type { Configuration } from '../src/generated';
+
+interface Options {
+  templateId: number;
+  managerFieldName: string;
+  userId: number;
+  dryRun: boolean;
+}
+
+const pageSize = 100;
+
+let opts: Options;
+let config: Configuration;
+let objectApi: ObjectApi;
+let taskApi: TaskApi;
+let managerFieldId: number;
+
+function parseArgs(args: string[]): Options {
+  const options: Options = {
+    templateId: 0,
+    managerFieldName: 'Менеджер',
+    userId: 0,
+    dryRun: false,
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--templateId') {
+      options.templateId = Number(args[++i]);
+    } else if (arg === '--managerFieldName') {
+      options.managerFieldName = args[++i];
+    } else if (arg === '--userId') {
+      options.userId = Number(args[++i]);
+    } else if (arg === '--dryRun') {
+      options.dryRun = true;
+    }
+  }
+
+  if (!options.templateId) {
+    throw new Error('templateId is required');
+  }
+  if (!options.managerFieldName) {
+    throw new Error('managerFieldName is required');
+  }
+  if (!options.userId) {
+    throw new Error('userId is required');
+  }
+
+  return options;
+}
+
+function getManagerId(task: TaskResponse): string | undefined {
+  const fieldValue = task.customFieldData?.find(
+    cf => cf.field?.id === managerFieldId,
+  )?.value as unknown;
+
+  if (!fieldValue) {
+    return undefined;
+  }
+
+  if (typeof fieldValue === 'number' || typeof fieldValue === 'string') {
+    return String(fieldValue);
+  }
+
+  if (typeof fieldValue === 'object' && 'id' in fieldValue) {
+    const value = (fieldValue as { id?: number | string | null }).id;
+    if (value == null) {
+      return undefined;
+    }
+    return String(value);
+  }
+
+  return undefined;
+}
+
+async function fetchManagerFieldId(): Promise<number> {
+  console.log(`Loading template ${opts.templateId}`);
+  const response = await objectApi.getObjectById({ id: opts.templateId });
+  const template = response.object;
+  if (!template) {
+    throw new Error(`Template ${opts.templateId} not found`);
+  }
+
+  const field = template.customFieldData?.find(
+    cf => cf.field?.name === opts.managerFieldName,
+  );
+  const fieldId = field?.field?.id;
+
+  if (!fieldId) {
+    throw new Error(
+      `Field "${opts.managerFieldName}" not found in template ${opts.templateId}`,
+    );
+  }
+
+  console.log(`Manager field id: ${fieldId}`);
+  return fieldId;
+}
+
+async function fetchTasks(): Promise<TaskResponse[]> {
+  const tasks: TaskResponse[] = [];
+  let offset = 0;
+
+  while (true) {
+    const requestFields = `id,name,${managerFieldId}`;
+    const response = await taskApi.getTaskList({
+      getTaskListRequest: {
+        pageSize,
+        offset,
+        fields: requestFields,
+        filters: [
+          {
+            type: ComplexTaskFilterTypeEnum.NUMBER_51,
+            operator: ComplexTaskFilterOperatorEnum.Equal,
+            value: opts.templateId,
+          },
+          {
+            type: ComplexTaskFilterTypeEnum.NUMBER_71,
+            operator: ComplexTaskFilterOperatorEnum.Equal,
+            value: opts.userId,
+          },
+        ],
+      },
+    });
+
+    const batch = (response.tasks ?? []) as TaskResponse[];
+    tasks.push(...batch);
+
+    if (batch.length < pageSize) {
+      break;
+    }
+
+    offset += pageSize;
+  }
+
+  return tasks;
+}
+
+async function setManagerForSubtasks(taskId: number, depth = 1): Promise<void> {
+  let offset = 0;
+  const userIdStr = String(opts.userId);
+
+  while (true) {
+    const response = await taskApi.getTaskList({
+      getTaskListRequest: {
+        pageSize,
+        offset,
+        fields: `id,name,${managerFieldId}`,
+        filters: [
+          {
+            type: ComplexTaskFilterTypeEnum.NUMBER_73,
+            operator: ComplexTaskFilterOperatorEnum.Equal,
+            value: taskId,
+          },
+        ],
+      },
+    });
+
+    const subtasks = (response.tasks ?? []) as TaskResponse[];
+
+    if (subtasks.length === 0) {
+      break;
+    }
+
+    for (const subtask of subtasks) {
+      const subtaskId = subtask.id;
+      if (!subtaskId) {
+        continue;
+      }
+
+      const managerId = getManagerId(subtask);
+      if (managerId !== userIdStr) {
+        const indent = '  '.repeat(depth);
+        console.log(
+          `${indent}Subtask ${subtaskId}${
+            subtask.name ? ` (${subtask.name})` : ''
+          }: manager ${managerId ?? 'none'} -> ${userIdStr}${
+            opts.dryRun ? ' (dry run)' : ''
+          }`,
+        );
+
+        if (!opts.dryRun) {
+          await taskApi.postTaskById({
+            id: subtaskId,
+            taskUpdateRequest: {
+              customFieldData: [
+                {
+                  field: { id: managerFieldId },
+                  value: { id: opts.userId },
+                },
+              ],
+            },
+          });
+        }
+      }
+
+      await setManagerForSubtasks(subtaskId, depth + 1);
+    }
+
+    if (subtasks.length < pageSize) {
+      break;
+    }
+
+    offset += pageSize;
+  }
+}
+
+export async function changeManagerInSubtasks() {
+  opts = parseArgs(process.argv.slice(2));
+  config = loadConfig();
+  objectApi = new ObjectApi(config);
+  taskApi = new TaskApi(config);
+
+  managerFieldId = await fetchManagerFieldId();
+
+  const tasks = await fetchTasks();
+  const userIdStr = String(opts.userId);
+  console.log(`Found ${tasks.length} tasks`);
+
+  for (const task of tasks) {
+    const taskId = task.id;
+    if (!taskId) {
+      continue;
+    }
+
+    const managerId = getManagerId(task);
+    if (managerId !== userIdStr) {
+      console.log(
+        `Task ${taskId}${task.name ? ` (${task.name})` : ''} manager ${
+          managerId ?? 'none'
+        } != ${userIdStr}`,
+      );
+    }
+
+    await setManagerForSubtasks(taskId);
+  }
+}
+
+if (require.main === module) {
+  changeManagerInSubtasks().catch(err => {
+    console.error(err);
+    process.exitCode = 1;
+  });
+}

--- a/examples/change-manager-in-subtasks.ts
+++ b/examples/change-manager-in-subtasks.ts
@@ -38,6 +38,17 @@ let taskApi: TaskApi;
 let managerFieldId: number;
 let logRows: LogRow[] = [];
 
+function isManagerMatch(managerValue: string | undefined, userId: number): boolean {
+  if (!managerValue) {
+    return false;
+  }
+
+  const trimmedValue = managerValue.trim();
+  const userIdStr = String(userId);
+
+  return trimmedValue === userIdStr || trimmedValue === `user:${userIdStr}`;
+}
+
 function parseArgs(args: string[]): Options {
   const options: Options = {
     templateId: 0,
@@ -266,7 +277,7 @@ async function setManagerForSubtasks(taskId: number, depth = 1): Promise<void> {
       }
 
       const managerId = getManagerId(subtask);
-      if (managerId !== userIdStr) {
+      if (!isManagerMatch(managerId, opts.userId)) {
         const indent = '  '.repeat(depth);
         console.log(
           `${indent}Subtask ${subtaskId}${
@@ -333,7 +344,7 @@ export async function changeManagerInSubtasks() {
       }
 
       const managerId = getManagerId(task);
-      if (managerId !== userIdStr) {
+      if (!isManagerMatch(managerId, opts.userId)) {
         console.log(
           `Task ${taskId}${task.name ? ` (${task.name})` : ''} manager ${
             managerId ?? 'none'

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "change-manager-by-client": "tsx examples/change-manager-by-client.ts --templateId 634921",
     "mass-update-contacts": "tsx examples/mass-update-contacts.ts",
     "fix-writing-tasks": "tsx examples/fix-writing-tasks.ts",
-    "fix-publications-with-false-paid": "tsx examples/fix-publications-with-false-paid.ts"
+    "fix-publications-with-false-paid": "tsx examples/fix-publications-with-false-paid.ts",
+    "change-manager-in-subtasks": "tsx examples/change-manager-in-subtasks.ts"
   },
   "keywords": [],
   "author": "",

--- a/src/generated/models/ComplexTaskFilter.ts
+++ b/src/generated/models/ComplexTaskFilter.ts
@@ -64,6 +64,7 @@ export interface ComplexTaskFilter {
  * @export
  */
 export const ComplexTaskFilterTypeEnum = {
+    USER: 2,
     NUMBER_8: 8,
     NUMBER_9: 9,
     NUMBER_10: 10,


### PR DESCRIPTION
## Summary
- add a change-manager-in-subtasks example script to synchronize the manager field in subtasks
- locate the manager custom field by template and recursively update mismatched subtasks with an optional dry run

## Testing
- npm test *(fails: network is unreachable for external Planfix API calls)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911cb988ef8832c94d8027fd34f68e8)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add example script to recursively synchronize subtask manager with CSV logging/dry-run, update filter enum with `USER`, and wire npm script.
> 
> - **Examples**:
>   - **New script** `examples/change-manager-in-subtasks.ts`:
>     - Parses CLI args, finds manager custom field by template, fetches tasks (filters: `NUMBER_51`, `USER`), recursively updates subtask manager via `TaskApi`, supports dry-run, and logs actions to CSV.
> - **Generated API**:
>   - Adds `USER` to `ComplexTaskFilterTypeEnum`.
> - **Package**:
>   - Adds npm script `change-manager-in-subtasks` in `package.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit efafb55c1c4dbe993c18642bd5189d035961f8a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->